### PR TITLE
Add Gemini CLI and mini DAW GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/gemini_cli.py
+++ b/gemini_cli.py
@@ -1,0 +1,26 @@
+import argparse
+import os
+
+try:
+    import google.generativeai as genai
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise SystemExit("google-generativeai package required. Install with `pip install google-generativeai`." ) from exc
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple CLI for Google Gemini API calls")
+    parser.add_argument("prompt", help="Prompt to send to the model")
+    parser.add_argument("--model", default="gemini-pro", help="Gemini model name")
+    parser.add_argument("--api-key", help="Google API key; otherwise set GOOGLE_API_KEY env var")
+    args = parser.parse_args()
+
+    api_key = args.api_key or os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        parser.error("An API key must be provided via --api-key or GOOGLE_API_KEY environment variable.")
+
+    genai.configure(api_key=api_key)
+    model = genai.GenerativeModel(args.model)
+    response = model.generate_content(args.prompt)
+    print(response.text)
+
+if __name__ == "__main__":
+    main()

--- a/mini_daw/README.md
+++ b/mini_daw/README.md
@@ -1,0 +1,31 @@
+# Mini DAW
+
+This directory contains a tiny Digital Audio Workstation implemented in
+pure Python.  It supports loading WAV files, placing them on tracks and
+mixing them down into a single output file.  Playback is available when
+the optional `sounddevice` package is installed.
+
+## Usage
+
+```
+python -m mini_daw.main <audio_folder> output.wav
+```
+
+The script searches the given folder for audio files and mixes the first
+two clips it finds.  A file system helper is provided in
+[`file_system.py`](file_system.py) for locating audio clips on disk.
+
+### Graphical interface
+
+The package also contains a minimal Tkinter-based GUI that can load and
+mix WAV files interactively:
+
+```
+python -m mini_daw.ui
+```
+
+Use the **Load Clips** button to add WAV files, then **Play Mix** or
+**Export Mix** to render the result.
+
+This code is intentionally minimal and is designed for educational
+purposes rather than production use.

--- a/mini_daw/__init__.py
+++ b/mini_daw/__init__.py
@@ -1,0 +1,9 @@
+"""Mini DAW package."""
+
+from .audio_clip import AudioClip
+from .daw import DAW
+from .file_system import list_audio_files
+from .track import Track
+from .ui import MiniDAWUI
+
+__all__ = ["AudioClip", "DAW", "Track", "list_audio_files", "MiniDAWUI"]

--- a/mini_daw/audio_clip.py
+++ b/mini_daw/audio_clip.py
@@ -1,0 +1,55 @@
+"""Representation of a single audio clip.
+
+The :class:`AudioClip` class wraps basic loading and manipulation of WAV
+files using the built-in :mod:`wave` module and :mod:`numpy` for math.
+"""
+
+from __future__ import annotations
+
+import wave
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+
+@dataclass
+class AudioClip:
+    """A short piece of audio loaded into memory."""
+
+    samples: np.ndarray
+    frame_rate: int
+    sample_width: int
+    channels: int
+
+    @classmethod
+    def from_wav(cls, filename: str | Path) -> "AudioClip":
+        """Load a clip from a WAV file."""
+        path = Path(filename)
+        with wave.open(str(path), "rb") as wf:
+            frame_rate = wf.getframerate()
+            sample_width = wf.getsampwidth()
+            channels = wf.getnchannels()
+            frames = wf.readframes(wf.getnframes())
+        dtype = {1: np.int8, 2: np.int16, 4: np.int32}[sample_width]
+        samples = np.frombuffer(frames, dtype=dtype)
+        if channels > 1:
+            samples = samples.reshape(-1, channels)
+        return cls(samples, frame_rate, sample_width, channels)
+
+    @property
+    def duration_seconds(self) -> float:
+        return len(self.samples) / self.frame_rate
+
+    def to_wav(self, filename: str | Path) -> None:
+        """Write the clip to a WAV file."""
+        path = Path(filename)
+        with wave.open(str(path), "wb") as wf:
+            wf.setnchannels(self.channels)
+            wf.setsampwidth(self.sample_width)
+            wf.setframerate(self.frame_rate)
+            wf.writeframes(self.samples.tobytes())
+
+
+__all__ = ["AudioClip"]

--- a/mini_daw/daw.py
+++ b/mini_daw/daw.py
@@ -1,0 +1,58 @@
+"""A very small Digital Audio Workstation in pure Python."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+import numpy as np
+
+from .audio_clip import AudioClip
+from .track import Track
+
+try:  # Optional playback support
+    import sounddevice as sd
+except Exception:  # pragma: no cover - sounddevice is optional
+    sd = None
+
+
+@dataclass
+class DAW:
+    tracks: List[Track] = field(default_factory=list)
+
+    def new_track(self) -> Track:
+        track = Track()
+        self.tracks.append(track)
+        return track
+
+    def render(self) -> AudioClip:
+        if not self.tracks:
+            return AudioClip(np.zeros(0, dtype=np.int16), 44100, 2, 1)
+        rendered = [track.mixdown() for track in self.tracks]
+        frame_rate = rendered[0].frame_rate
+        sample_width = rendered[0].sample_width
+        channels = rendered[0].channels
+        end_sample = max(len(r.samples) for r in rendered)
+        mix = np.zeros((end_sample, channels), dtype=np.int32)
+        for clip in rendered:
+            data = clip.samples
+            if clip.channels == 1 and channels == 2:
+                data = np.tile(data[:, None], (1, 2))
+            mix[:len(data)] += data
+        max_val = 2 ** (8 * sample_width - 1) - 1
+        mix = np.clip(mix, -max_val, max_val).astype({1: np.int8, 2: np.int16, 4: np.int32}[sample_width])
+        return AudioClip(mix, frame_rate, sample_width, channels)
+
+    def play(self) -> None:
+        """Play the current mix using :mod:`sounddevice` if available."""
+        if sd is None:
+            raise RuntimeError("sounddevice library not available")
+        clip = self.render()
+        sd.play(clip.samples, clip.frame_rate)
+        sd.wait()
+
+    def export(self, filename: str) -> None:
+        self.render().to_wav(filename)
+
+
+__all__ = ["DAW"]

--- a/mini_daw/file_system.py
+++ b/mini_daw/file_system.py
@@ -1,0 +1,39 @@
+"""File system utilities for accessing audio clips.
+
+This module provides a simple wrapper around the local file system to
+search for audio files. It intentionally avoids external dependencies so
+that it can run in minimal environments.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+
+AUDIO_EXTENSIONS: List[str] = [".wav", ".mp3", ".flac", ".ogg"]
+
+
+def list_audio_files(root: str | Path, extensions: Iterable[str] | None = None) -> List[Path]:
+    """Return a list of audio files under *root*.
+
+    Parameters
+    ----------
+    root:
+        Directory to search in.
+    extensions:
+        Optional iterable of file extensions to filter on.  If omitted,
+        :data:`AUDIO_EXTENSIONS` is used.
+    """
+
+    root_path = Path(root)
+    if extensions is None:
+        extensions = AUDIO_EXTENSIONS
+
+    result: List[Path] = []
+    for ext in extensions:
+        result.extend(root_path.rglob(f"*{ext}"))
+    return sorted(result)
+
+
+__all__ = ["list_audio_files", "AUDIO_EXTENSIONS"]

--- a/mini_daw/generate_tone.py
+++ b/mini_daw/generate_tone.py
@@ -1,0 +1,33 @@
+"""Utility to generate simple sine wave tones for testing."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+
+import numpy as np
+
+from .audio_clip import AudioClip
+
+
+def generate_tone(filename: str, frequency: float, duration: float, frame_rate: int = 44100) -> None:
+    t = np.linspace(0, duration, int(frame_rate * duration), False)
+    tone = 0.5 * np.sin(2 * math.pi * frequency * t)
+    samples = (tone * (2 ** 15 - 1)).astype(np.int16)
+    clip = AudioClip(samples, frame_rate, 2, 1)
+    clip.to_wav(filename)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a sine wave tone")
+    parser.add_argument("filename")
+    parser.add_argument("frequency", type=float)
+    parser.add_argument("duration", type=float)
+    args = parser.parse_args(argv)
+    generate_tone(args.filename, args.frequency, args.duration)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/mini_daw/main.py
+++ b/mini_daw/main.py
@@ -1,0 +1,48 @@
+"""Command line interface for the mini DAW.
+
+This script demonstrates basic usage of the :mod:`mini_daw` package. It
+scans a directory for audio files and mixes the first two files it finds
+onto separate tracks before exporting the result.
+"""
+
+from __future__ import annotations
+
+import argparse
+from .audio_clip import AudioClip
+from .daw import DAW
+from .file_system import list_audio_files
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Mini DAW example")
+    parser.add_argument("root", help="Directory containing audio clips")
+    parser.add_argument("output", help="Output WAV file")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+
+    files = list_audio_files(args.root)
+    if not files:
+        parser.error("no audio files found in given directory")
+
+    daw = DAW()
+    track1 = daw.new_track()
+    clip1 = AudioClip.from_wav(files[0])
+    track1.add_clip(clip1)
+
+    if len(files) > 1:
+        track2 = daw.new_track()
+        clip2 = AudioClip.from_wav(files[1])
+        # start second clip halfway through first clip
+        track2.add_clip(clip2, start_sample=len(clip1.samples) // 2)
+
+    daw.export(args.output)
+    print(f"Exported mix to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/mini_daw/track.py
+++ b/mini_daw/track.py
@@ -1,0 +1,46 @@
+"""Track management for the mini DAW."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+import numpy as np
+
+from .audio_clip import AudioClip
+
+
+@dataclass
+class Track:
+    clips: List[Tuple[AudioClip, int]] = field(default_factory=list)
+
+    def add_clip(self, clip: AudioClip, start_sample: int = 0) -> None:
+        self.clips.append((clip, start_sample))
+
+    def mixdown(self) -> AudioClip:
+        """Render the track to a single :class:`AudioClip`."""
+        if not self.clips:
+            return AudioClip(np.zeros(0, dtype=np.int16), 44100, 2, 1)
+
+        frame_rate = self.clips[0][0].frame_rate
+        sample_width = self.clips[0][0].sample_width
+        channels = self.clips[0][0].channels
+
+        end_sample = max(start + len(clip.samples) for clip, start in self.clips)
+        mix = np.zeros((end_sample, channels), dtype=np.int32)
+
+        for clip, start in self.clips:
+            data = clip.samples
+            if data.ndim == 1:
+                data = data[:, None]
+            if clip.channels == 1 and channels == 2:
+                data = np.tile(data, (1, 2))
+            mix[start:start + len(data)] += data
+
+        # Clip to valid range
+        max_val = 2 ** (8 * sample_width - 1) - 1
+        mix = np.clip(mix, -max_val, max_val).astype({1: np.int8, 2: np.int16, 4: np.int32}[sample_width])
+        return AudioClip(mix, frame_rate, sample_width, channels)
+
+
+__all__ = ["Track"]

--- a/mini_daw/ui.py
+++ b/mini_daw/ui.py
@@ -1,0 +1,82 @@
+"""Simple Tkinter user interface for the mini DAW.
+
+This module exposes a minimal graphical front end that allows users to
+load multiple WAV files, play the resulting mix (when the optional
+``sounddevice`` package is installed) and export the mix to a new WAV
+file.  The UI is intentionally basic and is meant for demonstration
+purposes only.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import filedialog, messagebox
+from typing import Iterable
+
+from .audio_clip import AudioClip
+from .daw import DAW
+
+
+class MiniDAWUI(tk.Tk):
+    """Small graphical front end for :mod:`mini_daw`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("Mini DAW")
+        self.geometry("400x300")
+
+        self.daw = DAW()
+
+        self.listbox = tk.Listbox(self)
+        self.listbox.pack(fill=tk.BOTH, expand=True)
+
+        controls = tk.Frame(self)
+        controls.pack(fill=tk.X)
+
+        tk.Button(controls, text="Load Clips", command=self.load_clips).pack(
+            side=tk.LEFT
+        )
+        tk.Button(controls, text="Play Mix", command=self.play_mix).pack(
+            side=tk.LEFT
+        )
+        tk.Button(controls, text="Export Mix", command=self.export_mix).pack(
+            side=tk.LEFT
+        )
+
+    def load_clips(self) -> None:
+        """Ask the user for WAV files and add them to the project."""
+        filenames: Iterable[str] = filedialog.askopenfilenames(
+            title="Select WAV files", filetypes=[("WAV", "*.wav")]
+        )
+        for filename in filenames:
+            clip = AudioClip.from_wav(filename)
+            track = self.daw.new_track()
+            track.add_clip(clip)
+            self.listbox.insert(tk.END, filename)
+
+    def play_mix(self) -> None:
+        """Render and play the current mix."""
+        try:
+            self.daw.play()
+        except Exception as exc:  # pragma: no cover - GUI feedback only
+            messagebox.showerror("Playback error", str(exc))
+
+    def export_mix(self) -> None:
+        """Render and export the current mix to a WAV file."""
+        filename = filedialog.asksaveasfilename(
+            title="Export Mix",
+            defaultextension=".wav",
+            filetypes=[("WAV", "*.wav")],
+        )
+        if filename:
+            self.daw.export(filename)
+            messagebox.showinfo("Export complete", f"Mix exported to {filename}")
+
+
+def main() -> None:  # pragma: no cover - manual execution
+    app = MiniDAWUI()
+    app.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()


### PR DESCRIPTION
## Summary
- provide standalone command line for Google Gemini API calls
- implement a minimal Python digital audio workstation with file-system audio clip access
- add Tkinter-based GUI to load clips, play mixes, and export WAV files

## Testing
- `python3 -m py_compile mini_daw/*.py gemini_cli.py`
- `python3 -m mini_daw.generate_tone tmp_audio/tone1.wav 440 1` *(fails: ModuleNotFoundError: No module named 'numpy'; `pip install numpy` blocked by externally-managed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a40d8db72c8325be99ac7cbd9b8531